### PR TITLE
Added vec_clear and vec_find. Implemented lazy init

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
 [*]
 indent_style = tab
-indensize_t = 4
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -126,23 +126,25 @@ typedef struct s_vec
     size_t          len;
 }   t_vec;
 
-int     vec_new(t_vec *src, size_t init_alloc, size_t elem_size);
-void    vec_free(t_vec *src);
-int     vec_from(t_vec *dst, void *src, size_t len, size_t elem_size);
-int     vec_resize(t_vec *src, size_t target_size);
-int     vec_push(t_vec *src, void *elem);
-int     vec_pop(void *dst, t_vec *src);
-int     vec_copy(t_vec *dst, t_vec *src);
-void    *vec_get(t_vec *src, size_t index);
-int     vec_insert(t_vec *dst, void *elem, size_t index);
-int     vec_remove(t_vec *src, size_t index);
-int     vec_append(t_vec *dst, t_vec *src);
-int     vec_prepend(t_vec *dst, t_vec *src);
-void    vec_iter(t_vec *src, void (*f) (void *));
-int     vec_map(t_vec *dst, t_vec *src, void (*f) (void *));
-int     vec_filter(t_vec *dst, t_vec *src, bool (*f) (void *));
-int     vec_reduce(void *dst, t_vec *src, void (*f) (void *, void *));
-void    vec_sort(t_vec *src, int (*f)(void *, void *));
+int		vec_new(t_vec *src, size_t init_len, size_t elem_size);
+void	vec_free(t_vec *src);
+int		vec_from(t_vec *dst, void *src, size_t len, size_t elem_size);
+int		vec_resize(t_vec *src, size_t target_size);
+int		vec_clear(t_vec *src);
+int	 	vec_push(t_vec *src, void *elem);
+int	 	vec_pop(void *dst, t_vec *src);
+int	 	vec_copy(t_vec *dst, t_vec *src);
+void	*vec_get(t_vec *src, size_t index);
+int		vec_insert(t_vec *dst, void *elem, size_t index);
+int		vec_remove(t_vec *src, size_t index);
+int	 	vec_append(t_vec *dst, t_vec *src);
+int	 	vec_prepend(t_vec *dst, t_vec *src);
+void	vec_iter(t_vec *src, void (*f) (void *));
+void	*vec_find(t_vec *src, bool (*f) (void *));
+int		vec_map(t_vec *dst, t_vec *src, void (*f) (void *));
+int		vec_filter(t_vec *dst, t_vec *src, bool (*f) (void *));
+int	 	vec_reduce(void *dst, t_vec *src, void (*f) (void *, void *));
+void	vec_sort(t_vec *src, int (*f)(void *, void *));
 
 #endif
 

--- a/subject.md
+++ b/subject.md
@@ -76,23 +76,25 @@ typedef struct s_vec
     size_t          len;
 }   t_vec;
 
-int     vec_new(t_vec *src, size_t init_alloc, size_t elem_size);
-void    vec_free(t_vec *src);
-int     vec_from(t_vec *dst, void *src, size_t len, size_t elem_size);
-int     vec_resize(t_vec *src, size_t target_size);
-int     vec_push(t_vec *src, void *elem);
-int     vec_pop(void *dst, t_vec *src);
-int     vec_copy(t_vec *dst, t_vec *src);
-void    *vec_get(t_vec *src, size_t index);
-int     vec_insert(t_vec *dst, void *elem, size_t index);
-int     vec_remove(t_vec *src, size_t index);
-int     vec_append(t_vec *dst, t_vec *src);
-int     vec_prepend(t_vec *dst, t_vec *src);
-void    vec_iter(t_vec *src, void (*f) (void *));
-int     vec_map(t_vec *dst, t_vec *src, void (*f) (void *));
-int     vec_filter(t_vec *dst, t_vec *src, bool (*f) (void *));
-int     vec_reduce(void *dst, t_vec *src, void (*f) (void *, void *));
-void    vec_sort(t_vec *src, int (*f)(void *, void *));
+int		vec_new(t_vec *src, size_t init_len, size_t elem_size);
+void	vec_free(t_vec *src);
+int		vec_from(t_vec *dst, void *src, size_t len, size_t elem_size);
+int		vec_resize(t_vec *src, size_t target_size);
+int		vec_clear(t_vec *src);
+int	 	vec_push(t_vec *src, void *elem);
+int	 	vec_pop(void *dst, t_vec *src);
+int	 	vec_copy(t_vec *dst, t_vec *src);
+void	*vec_get(t_vec *src, size_t index);
+int		vec_insert(t_vec *dst, void *elem, size_t index);
+int		vec_remove(t_vec *src, size_t index);
+int	 	vec_append(t_vec *dst, t_vec *src);
+int	 	vec_prepend(t_vec *dst, t_vec *src);
+void	vec_iter(t_vec *src, void (*f) (void *));
+void	*vec_find(t_vec *src, bool (*f) (void *));
+int		vec_map(t_vec *dst, t_vec *src, void (*f) (void *));
+int		vec_filter(t_vec *dst, t_vec *src, bool (*f) (void *));
+int	 	vec_reduce(void *dst, t_vec *src, void (*f) (void *, void *));
+void	vec_sort(t_vec *src, int (*f)(void *, void *));
 
 #endif
 
@@ -106,7 +108,7 @@ initialize its length and element size.
 
 ```c
 
-int vec_new(t_vec *dst, size_t init_alloc, size_t elem_size);
+int vec_new(t_vec *dst, size_t init_len, size_t elem_size);
 
 int main(void)
 {

--- a/utests.c
+++ b/utests.c
@@ -2,12 +2,18 @@
 #include "assert.h"
 #include "stdio.h"
 
+void print_int(void *ptr)
+{
+	printf("%d\n", *(int *)ptr);
+}
+
 void test_vec_new()
 {
 	t_vec t1;
 
 	assert(vec_new(&t1, 0, 0) == -1);
-	assert(vec_new(&t1, 0, 1) == -1);
+	assert(vec_new(&t1, 0, 1) > 0);
+	assert(t1.memory == NULL);
 	assert(vec_new(&t1, 1, 0) == -1);
 	assert(vec_new(&t1, 10, 1) > 0);
 	assert(t1.memory != NULL);
@@ -45,8 +51,8 @@ void test_vec_copy()
 	t_vec	t2;
 	int		base[] = {1, 2, 3, 4, 5};
 
-	assert(vec_from(&t1, base, 5, sizeof(int)) > 0);
-	assert(vec_new(&t2, 5, sizeof(int)) > 0);
+	assert(vec_from(&t1, base, sizeof(base) / sizeof(int), sizeof(int)) > 0);
+	assert(vec_new(&t2, sizeof(base) / sizeof(int), sizeof(int)) > 0);
 	assert(vec_copy(&t2, &t1) > 0);
 	assert(memcmp(t2.memory, base, sizeof(base)) == 0);
 	vec_free(&t1);

--- a/utests.c
+++ b/utests.c
@@ -118,6 +118,7 @@ void test_vec_get()
 	expect = vec_get(&t1, 1);
 	assert(*expect == 4);
 	assert(t1.len == 2);
+	assert(vec_get(&t1, 2) == NULL);
 	vec_free(&t1);
 	printf("test_vec_get successful!\n");
 }

--- a/vec.c
+++ b/vec.c
@@ -1,26 +1,26 @@
 #include "vec.h"
 
-int vec_new(t_vec *dst, size_t init_alloc, size_t elem_size)
+int vec_new(t_vec *dst, size_t init_len, size_t elem_size)
 {
-    if (!dst || elem_size == 0 || init_alloc == 0)
+    if (!dst || elem_size == 0)
         return (-1);
-    dst->alloc_size = init_alloc * elem_size;
+    dst->alloc_size = init_len * elem_size;
     dst->len = 0;
     dst->elem_size = elem_size;
-    dst->memory = malloc(dst->alloc_size);
-    if (!dst->memory)
-    {
-        dst->alloc_size = 0;
-        dst->len = 0;
-        dst->elem_size = 0;
-        return (-1);
-    }
+	if (init_len == 0)
+		dst->memory = NULL;
+	else
+	{
+    	dst->memory = malloc(dst->alloc_size);
+		if (!dst->memory)
+			return (-1);
+	}
     return (1);
 }
 
 void vec_free(t_vec *src)
 {
-    if (!src)
+    if (!src || src->alloc_size == 0)
         return ;
     free(src->memory);
     src->memory = NULL;
@@ -31,48 +31,52 @@ void vec_free(t_vec *src)
 
 int vec_from(t_vec *dst, void *src, size_t len, size_t elem_size)
 {
-    if (!src || !src || elem_size == 0)
+    if (!dst || !src || elem_size == 0)
         return (-1);
-    dst->alloc_size = len * elem_size;
-    dst->len = len;
-    dst->elem_size = elem_size;
-    dst->memory = malloc(dst->alloc_size);
-    if (!dst->memory)
-    {
-        dst->alloc_size = 0;
-        dst->len = 0;
-        dst->elem_size = 0;
-        return (-1);
-    }
-    dst->memory = memcpy(dst->memory, src, dst->alloc_size);
-    return (1);
+	else if (vec_new(dst, len, elem_size) < 0)
+		return (-1);
+	memcpy(
+		dst->memory,
+		src,
+		dst->alloc_size);
+	dst->len = len;
+	return (1);
 }
 
 int vec_copy(t_vec *dst, t_vec *src)
 {
     size_t  copy_size;
 
-    if (!dst || !src)
+    if (!dst || !src || !src->memory)
         return (-1);
+	else if (!dst->memory)
+		vec_new(dst, src->len, dst->elem_size);
     if (src->len * src->elem_size < dst->alloc_size)
         copy_size = src->len * src->elem_size;
     else
         copy_size = src->alloc_size;
-    memcpy(dst->memory, src->memory, copy_size);
+    memcpy(
+		dst->memory,
+		src->memory,
+		copy_size);
+	dst->len = copy_size / dst->elem_size;
     return (1);
 }
 
-int vec_resize(t_vec *src, size_t target_size)
+int vec_resize(t_vec *src, size_t target_len)
 {
     t_vec   dst;
-    int     ret;
 
     if (!src)
         return (-1);
-    ret = vec_new(&dst, target_size / src->elem_size, src->elem_size);
-    if (ret < 0)
-        return (-1);
-    memcpy(dst.memory, src->memory, src->alloc_size);
+	else if (!src->memory)
+		return vec_new(src, target_len, src->elem_size);
+    else if (vec_new(&dst, target_len, src->elem_size) < 0)
+		return (-1);
+    memcpy(
+		dst.memory,
+		src->memory,
+		src->len * src->elem_size);
     dst.len = src->len;
     vec_copy(&dst, src);
     vec_free(src);
@@ -80,100 +84,95 @@ int vec_resize(t_vec *src, size_t target_size)
     return (1);
 }
 
+void *vec_get(t_vec *src, size_t index)
+{
+    unsigned char   *ptr;
+
+    if (index > src->len || !src || !src->memory)
+        return (NULL);
+    ptr = &src->memory[src->elem_size * index];
+    return (ptr);
+}
+
 int vec_push(t_vec *dst, void *src)
 {
-    unsigned char   *target;
-    int             ret;
-
     if (!dst || !src)
         return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
     if (dst->elem_size * dst->len >= dst->alloc_size)
-    {
-        ret = vec_resize(dst, dst->alloc_size * 2);
-        if (ret < 0)
+        if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
             return (-1);
-    }
-    target = &dst->memory[dst->elem_size * dst->len];
-    memcpy(target, src, dst->elem_size);
+    memcpy(vec_get(dst, dst->len), src, dst->elem_size);
     dst->len++;
     return (1);
 }
 
 int vec_pop(void *dst, t_vec *src)
 {
-    unsigned char   *target;
-
     if (!dst || !src)
         return (-1);
-    if (src->memory == NULL || src->len == 0)
-        return (-1);
-    target = &src->memory[src->elem_size * (src->len - 1)];
-    memcpy(dst, target, src->elem_size);
+    else if (!src->memory || src->len == 0)
+        return (0);
+    memcpy(dst, vec_get(src, src->len - 1), src->elem_size);
     src->len--;
     return (1);
 }
 
-void *vec_get(t_vec *src, size_t index)
+int vec_clear(t_vec *src)
 {
-    unsigned char   *ptr;
-
-    if (index > src->len || !src)
-        return (NULL);
-    ptr = &src->memory[src->elem_size * index];
-    return (ptr);
+	if (!src)
+		return (-1);
+	src->len = 0;
+	return (1);
 }
 
 int vec_insert(t_vec *dst, void *src, size_t index)
 {
-    unsigned char   *pos;
-    unsigned char   *mov_pos;
-    int             ret;
-
     if (!dst || !src || index > dst->len)
         return (-1);
-    if (index == dst->len)
+    else if (index == dst->len)
         return (vec_push(dst, src));
     if (dst->elem_size * dst->len >= dst->alloc_size)
-    {
-        ret = vec_resize(dst, dst->alloc_size * 2);
-        if (ret < 0)
+        if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
             return (-1);
-    }
-    pos = vec_get(dst, index);
-    mov_pos = vec_get(dst, index + 1);
-    memmove(mov_pos, pos, (dst->len - index) * dst->elem_size);
-    memcpy(pos, src, dst->elem_size);
+    memmove(
+		vec_get(dst, index + 1),
+		vec_get(dst, index),
+		(dst->len - index) * dst->elem_size);
+    memcpy(
+		vec_get(dst, index),
+		src, dst->elem_size);
     dst->len++;
     return (1);
 }
 
 int vec_remove(t_vec *src, size_t index)
 {
-    unsigned char   *pos;
-    unsigned char   *mov_pos;
-
     if (!src || index > src->len)
         return (-1);
-    if (index == src->len)
+    else if (index == src->len)
     {
         src->len--;
         return (1);
     }
-    pos = vec_get(src, index + 1);
-    mov_pos = vec_get(src, index);
-    memmove(mov_pos, pos, (src->len - index) * src->elem_size);
+    memmove(
+		vec_get(src, index),
+		vec_get(src, index + 1),
+		(src->len - index) * src->elem_size);
     src->len--;
     return (1);
 }
 
 int vec_append(t_vec *dst, t_vec *src)
 {
-    unsigned char   *pos;
     int             ret;
     size_t          alloc_size;
 
-    if (!dst || !src)
+    if (!dst || !src || !src->memory)
         return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
     alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
     if (dst->alloc_size < alloc_size)
     {
@@ -184,29 +183,32 @@ int vec_append(t_vec *dst, t_vec *src)
         if (ret < 0)
             return (-1);
     }
-    pos = vec_get(dst, dst->len);
-    memcpy(pos, src->memory, src->len * src->elem_size);
+    memcpy(
+		vec_get(dst, dst->len),
+		src->memory,
+		src->len * src->elem_size);
     dst->len += src->len;
     return (1);
 }
 
 int vec_prepend(t_vec *dst, t_vec *src)
 {
-    unsigned char   *pos;
-    int             ret;
     t_vec           new;
     size_t          alloc_size;
 
     if (!dst || !src)
         return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
     alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
-    ret = vec_new(&new, alloc_size / dst->elem_size, dst->elem_size);
-    if (ret < 0)
+    if (vec_new(&new, alloc_size / dst->elem_size, dst->elem_size) < 0)
         return (-1);
     vec_copy(&new, src);
     new.len = src->len + dst->len;
-    pos = vec_get(&new, src->len);
-    memcpy(pos, dst->memory, dst->len * dst->elem_size);
+    memcpy(
+		vec_get(&new, src->len),
+		dst->memory,
+		dst->len * dst->elem_size);
     vec_free(dst);
     *dst = new;
     return (1);
@@ -217,7 +219,7 @@ void vec_iter(t_vec *src, void (*f) (void *))
     void    *ptr;
     size_t  i;
 
-    if (!src)
+    if (!src || !src->memory)
         return ;
     i = 0;
     while (i < src->len)
@@ -228,14 +230,34 @@ void vec_iter(t_vec *src, void (*f) (void *))
     }
 }
 
+void *vec_find(t_vec *src, bool (*f) (void *))
+{
+    void    *ptr;
+    size_t  i;
+
+    if (!src || !src->memory)
+        return (NULL);
+    i = 0;
+    while (i < src->len)
+    {
+        ptr = vec_get(src, i);
+        if (f(ptr) == true)
+			return (ptr);
+        i++;
+    }
+	return (NULL);
+}
+
 int vec_map(t_vec *dst, t_vec *src, void (*f) (void *))
 {
     void    *ptr;
     void    *res;
     size_t  i;
 
-    if (!dst || !src)
+    if (!dst || !src || !src->memory)
         return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
     res = malloc(dst->elem_size);
     if (!res)
         return (-1);
@@ -258,8 +280,10 @@ int vec_filter(t_vec *dst, t_vec *src, bool (*f) (void *))
     void    *res;
     size_t  i;
 
-    if (!dst || !src)
+    if (!dst || !src || !src->memory)
         return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
     res = malloc(dst->elem_size);
     if (!res)
         return (-1);
@@ -281,7 +305,7 @@ int vec_reduce(void *dst, t_vec *src, void (*f) (void *, void *))
     void    *ptr;
     size_t  i;
 
-    if (!dst || !src)
+    if (!dst || !src || !src->memory)
         return (-1);
     i = 0;
     while (i < src->len)
@@ -346,7 +370,7 @@ static void vec_sort_recurse(t_vec *src,
 
 void    vec_sort(t_vec *src, int (*f)(void *, void *))
 {
-    if (!src)
+    if (!src || !src->memory)
         return ;
     vec_sort_recurse(src, 0, src->len - 1, f);
 }

--- a/vec.c
+++ b/vec.c
@@ -7,14 +7,14 @@ int vec_new(t_vec *dst, size_t init_len, size_t elem_size)
     dst->alloc_size = init_len * elem_size;
     dst->len = 0;
     dst->elem_size = elem_size;
-	if (init_len == 0)
-		dst->memory = NULL;
-	else
-	{
-    	dst->memory = malloc(dst->alloc_size);
-		if (!dst->memory)
-			return (-1);
-	}
+        if (init_len == 0)
+                dst->memory = NULL;
+        else
+        {
+        dst->memory = malloc(dst->alloc_size);
+                if (!dst->memory)
+                        return (-1);
+        }
     return (1);
 }
 
@@ -33,14 +33,14 @@ int vec_from(t_vec *dst, void *src, size_t len, size_t elem_size)
 {
     if (!dst || !src || elem_size == 0)
         return (-1);
-	else if (vec_new(dst, len, elem_size) < 0)
-		return (-1);
-	memcpy(
-		dst->memory,
-		src,
-		dst->alloc_size);
-	dst->len = len;
-	return (1);
+        else if (vec_new(dst, len, elem_size) < 0)
+                return (-1);
+        memcpy(
+                dst->memory,
+                src,
+                dst->alloc_size);
+        dst->len = len;
+        return (1);
 }
 
 int vec_copy(t_vec *dst, t_vec *src)
@@ -49,17 +49,17 @@ int vec_copy(t_vec *dst, t_vec *src)
 
     if (!dst || !src || !src->memory)
         return (-1);
-	else if (!dst->memory)
-		vec_new(dst, src->len, dst->elem_size);
+        else if (!dst->memory)
+                vec_new(dst, src->len, dst->elem_size);
     if (src->len * src->elem_size < dst->alloc_size)
         copy_size = src->len * src->elem_size;
     else
         copy_size = src->alloc_size;
     memcpy(
-		dst->memory,
-		src->memory,
-		copy_size);
-	dst->len = copy_size / dst->elem_size;
+                dst->memory,
+                src->memory,
+                copy_size);
+        dst->len = copy_size / dst->elem_size;
     return (1);
 }
 
@@ -69,14 +69,14 @@ int vec_resize(t_vec *src, size_t target_len)
 
     if (!src)
         return (-1);
-	else if (!src->memory)
-		return vec_new(src, target_len, src->elem_size);
+        else if (!src->memory)
+                return vec_new(src, target_len, src->elem_size);
     else if (vec_new(&dst, target_len, src->elem_size) < 0)
-		return (-1);
+                return (-1);
     memcpy(
-		dst.memory,
-		src->memory,
-		src->len * src->elem_size);
+                dst.memory,
+                src->memory,
+                src->len * src->elem_size);
     dst.len = src->len;
     vec_copy(&dst, src);
     vec_free(src);
@@ -98,8 +98,8 @@ int vec_push(t_vec *dst, void *src)
 {
     if (!dst || !src)
         return (-1);
-	else if (!dst->memory)
-		vec_new(dst, 1, dst->elem_size);
+        else if (!dst->memory)
+                vec_new(dst, 1, dst->elem_size);
     if (dst->elem_size * dst->len >= dst->alloc_size)
         if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
             return (-1);
@@ -121,10 +121,10 @@ int vec_pop(void *dst, t_vec *src)
 
 int vec_clear(t_vec *src)
 {
-	if (!src)
-		return (-1);
-	src->len = 0;
-	return (1);
+        if (!src)
+                return (-1);
+        src->len = 0;
+        return (1);
 }
 
 int vec_insert(t_vec *dst, void *src, size_t index)
@@ -137,12 +137,12 @@ int vec_insert(t_vec *dst, void *src, size_t index)
         if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
             return (-1);
     memmove(
-		vec_get(dst, index + 1),
-		vec_get(dst, index),
-		(dst->len - index) * dst->elem_size);
+                vec_get(dst, index + 1),
+                vec_get(dst, index),
+                (dst->len - index) * dst->elem_size);
     memcpy(
-		vec_get(dst, index),
-		src, dst->elem_size);
+                vec_get(dst, index),
+                src, dst->elem_size);
     dst->len++;
     return (1);
 }
@@ -157,9 +157,9 @@ int vec_remove(t_vec *src, size_t index)
         return (1);
     }
     memmove(
-		vec_get(src, index),
-		vec_get(src, index + 1),
-		(src->len - index) * src->elem_size);
+                vec_get(src, index),
+                vec_get(src, index + 1),
+                (src->len - index) * src->elem_size);
     src->len--;
     return (1);
 }
@@ -171,8 +171,8 @@ int vec_append(t_vec *dst, t_vec *src)
 
     if (!dst || !src || !src->memory)
         return (-1);
-	else if (!dst->memory)
-		vec_new(dst, 1, dst->elem_size);
+        else if (!dst->memory)
+                vec_new(dst, 1, dst->elem_size);
     alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
     if (dst->alloc_size < alloc_size)
     {
@@ -184,9 +184,9 @@ int vec_append(t_vec *dst, t_vec *src)
             return (-1);
     }
     memcpy(
-		vec_get(dst, dst->len),
-		src->memory,
-		src->len * src->elem_size);
+                vec_get(dst, dst->len),
+                src->memory,
+                src->len * src->elem_size);
     dst->len += src->len;
     return (1);
 }
@@ -198,17 +198,17 @@ int vec_prepend(t_vec *dst, t_vec *src)
 
     if (!dst || !src)
         return (-1);
-	else if (!dst->memory)
-		vec_new(dst, 1, dst->elem_size);
+        else if (!dst->memory)
+                vec_new(dst, 1, dst->elem_size);
     alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
     if (vec_new(&new, alloc_size / dst->elem_size, dst->elem_size) < 0)
         return (-1);
     vec_copy(&new, src);
     new.len = src->len + dst->len;
     memcpy(
-		vec_get(&new, src->len),
-		dst->memory,
-		dst->len * dst->elem_size);
+                vec_get(&new, src->len),
+                dst->memory,
+                dst->len * dst->elem_size);
     vec_free(dst);
     *dst = new;
     return (1);
@@ -242,10 +242,10 @@ void *vec_find(t_vec *src, bool (*f) (void *))
     {
         ptr = vec_get(src, i);
         if (f(ptr) == true)
-			return (ptr);
+                        return (ptr);
         i++;
     }
-	return (NULL);
+        return (NULL);
 }
 
 int vec_map(t_vec *dst, t_vec *src, void (*f) (void *))
@@ -256,8 +256,8 @@ int vec_map(t_vec *dst, t_vec *src, void (*f) (void *))
 
     if (!dst || !src || !src->memory)
         return (-1);
-	else if (!dst->memory)
-		vec_new(dst, 1, dst->elem_size);
+        else if (!dst->memory)
+                vec_new(dst, 1, dst->elem_size);
     res = malloc(dst->elem_size);
     if (!res)
         return (-1);
@@ -282,8 +282,8 @@ int vec_filter(t_vec *dst, t_vec *src, bool (*f) (void *))
 
     if (!dst || !src || !src->memory)
         return (-1);
-	else if (!dst->memory)
-		vec_new(dst, 1, dst->elem_size);
+        else if (!dst->memory)
+                vec_new(dst, 1, dst->elem_size);
     res = malloc(dst->elem_size);
     if (!res)
         return (-1);

--- a/vec.c
+++ b/vec.c
@@ -33,14 +33,14 @@ int vec_from(t_vec *dst, void *src, size_t len, size_t elem_size)
 {
     if (!dst || !src || elem_size == 0)
         return (-1);
-        else if (vec_new(dst, len, elem_size) < 0)
-                return (-1);
-        memcpy(
-                dst->memory,
-                src,
-                dst->alloc_size);
-        dst->len = len;
-        return (1);
+    else if (vec_new(dst, len, elem_size) < 0)
+        return (-1);
+    memcpy(
+        dst->memory,
+        src,
+        dst->alloc_size);
+    dst->len = len;
+    return (1);
 }
 
 int vec_copy(t_vec *dst, t_vec *src)
@@ -49,16 +49,16 @@ int vec_copy(t_vec *dst, t_vec *src)
 
     if (!dst || !src || !src->memory)
         return (-1);
-        else if (!dst->memory)
-                vec_new(dst, src->len, dst->elem_size);
+    else if (!dst->memory)
+        vec_new(dst, src->len, dst->elem_size);
     if (src->len * src->elem_size < dst->alloc_size)
         copy_size = src->len * src->elem_size;
     else
         copy_size = src->alloc_size;
     memcpy(
-                dst->memory,
-                src->memory,
-                copy_size);
+        dst->memory,
+        src->memory,
+        copy_size);
         dst->len = copy_size / dst->elem_size;
     return (1);
 }
@@ -69,14 +69,14 @@ int vec_resize(t_vec *src, size_t target_len)
 
     if (!src)
         return (-1);
-        else if (!src->memory)
-                return vec_new(src, target_len, src->elem_size);
+    else if (!src->memory)
+        return vec_new(src, target_len, src->elem_size);
     else if (vec_new(&dst, target_len, src->elem_size) < 0)
-                return (-1);
+        return (-1);
     memcpy(
-                dst.memory,
-                src->memory,
-                src->len * src->elem_size);
+        dst.memory,
+        src->memory,
+        src->len * src->elem_size);
     dst.len = src->len;
     vec_copy(&dst, src);
     vec_free(src);
@@ -98,8 +98,8 @@ int vec_push(t_vec *dst, void *src)
 {
     if (!dst || !src)
         return (-1);
-        else if (!dst->memory)
-                vec_new(dst, 1, dst->elem_size);
+    else if (!dst->memory)
+        vec_new(dst, 1, dst->elem_size);
     if (dst->elem_size * dst->len >= dst->alloc_size)
         if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
             return (-1);
@@ -121,10 +121,10 @@ int vec_pop(void *dst, t_vec *src)
 
 int vec_clear(t_vec *src)
 {
-        if (!src)
-                return (-1);
-        src->len = 0;
-        return (1);
+    if (!src)
+        return (-1);
+    src->len = 0;
+    return (1);
 }
 
 int vec_insert(t_vec *dst, void *src, size_t index)
@@ -137,12 +137,12 @@ int vec_insert(t_vec *dst, void *src, size_t index)
         if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
             return (-1);
     memmove(
-                vec_get(dst, index + 1),
-                vec_get(dst, index),
-                (dst->len - index) * dst->elem_size);
+        vec_get(dst, index + 1),
+        vec_get(dst, index),
+        (dst->len - index) * dst->elem_size);
     memcpy(
-                vec_get(dst, index),
-                src, dst->elem_size);
+        vec_get(dst, index),
+        src, dst->elem_size);
     dst->len++;
     return (1);
 }
@@ -157,22 +157,22 @@ int vec_remove(t_vec *src, size_t index)
         return (1);
     }
     memmove(
-                vec_get(src, index),
-                &src->memory[src->elem_size * (index + 1)],
-                (src->len - index) * src->elem_size);
+        vec_get(src, index),
+        &src->memory[src->elem_size * (index + 1)],
+        (src->len - index) * src->elem_size);
     src->len--;
     return (1);
 }
 
 int vec_append(t_vec *dst, t_vec *src)
 {
-    int             ret;
-    size_t          alloc_size;
+    int     ret;
+    size_t  alloc_size;
 
     if (!dst || !src || !src->memory)
         return (-1);
-        else if (!dst->memory)
-                vec_new(dst, 1, dst->elem_size);
+    else if (!dst->memory)
+        vec_new(dst, 1, dst->elem_size);
     alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
     if (dst->alloc_size < alloc_size)
     {
@@ -193,13 +193,13 @@ int vec_append(t_vec *dst, t_vec *src)
 
 int vec_prepend(t_vec *dst, t_vec *src)
 {
-    t_vec           new;
-    size_t          alloc_size;
+    t_vec    new;
+    size_t   alloc_size;
 
     if (!dst || !src)
         return (-1);
-        else if (!dst->memory)
-                vec_new(dst, 1, dst->elem_size);
+    else if (!dst->memory)
+        vec_new(dst, 1, dst->elem_size);
     alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
     if (vec_new(&new, alloc_size / dst->elem_size, dst->elem_size) < 0)
         return (-1);
@@ -242,10 +242,10 @@ void *vec_find(t_vec *src, bool (*f) (void *))
     {
         ptr = vec_get(src, i);
         if (f(ptr) == true)
-                        return (ptr);
+            return (ptr);
         i++;
     }
-        return (NULL);
+    return (NULL);
 }
 
 int vec_map(t_vec *dst, t_vec *src, void (*f) (void *))
@@ -256,8 +256,8 @@ int vec_map(t_vec *dst, t_vec *src, void (*f) (void *))
 
     if (!dst || !src || !src->memory)
         return (-1);
-        else if (!dst->memory)
-                vec_new(dst, 1, dst->elem_size);
+    else if (!dst->memory)
+        vec_new(dst, 1, dst->elem_size);
     res = malloc(dst->elem_size);
     if (!res)
         return (-1);
@@ -282,8 +282,8 @@ int vec_filter(t_vec *dst, t_vec *src, bool (*f) (void *))
 
     if (!dst || !src || !src->memory)
         return (-1);
-        else if (!dst->memory)
-                vec_new(dst, 1, dst->elem_size);
+    else if (!dst->memory)
+        vec_new(dst, 1, dst->elem_size);
     res = malloc(dst->elem_size);
     if (!res)
         return (-1);

--- a/vec.c
+++ b/vec.c
@@ -2,374 +2,374 @@
 
 int vec_new(t_vec *dst, size_t init_len, size_t elem_size)
 {
-    if (!dst || elem_size == 0)
-        return (-1);
-    dst->alloc_size = init_len * elem_size;
-    dst->len = 0;
-    dst->elem_size = elem_size;
-        if (init_len == 0)
-                dst->memory = NULL;
-        else
-        {
-        dst->memory = malloc(dst->alloc_size);
-                if (!dst->memory)
-                        return (-1);
-        }
-    return (1);
+	if (!dst || elem_size == 0)
+		return (-1);
+	dst->alloc_size = init_len * elem_size;
+	dst->len = 0;
+	dst->elem_size = elem_size;
+	if (init_len == 0)
+		dst->memory = NULL;
+	else
+	{
+		dst->memory = malloc(dst->alloc_size);
+		if (!dst->memory)
+			return (-1);
+	}
+	return (1);
 }
 
 void vec_free(t_vec *src)
 {
-    if (!src || src->alloc_size == 0)
-        return ;
-    free(src->memory);
-    src->memory = NULL;
-    src->alloc_size = 0;
-    src->elem_size = 0;
-    src->len = 0;
+	if (!src || src->alloc_size == 0)
+		return ;
+	free(src->memory);
+	src->memory = NULL;
+	src->alloc_size = 0;
+	src->elem_size = 0;
+	src->len = 0;
 }
 
 int vec_from(t_vec *dst, void *src, size_t len, size_t elem_size)
 {
-    if (!dst || !src || elem_size == 0)
-        return (-1);
-    else if (vec_new(dst, len, elem_size) < 0)
-        return (-1);
-    memcpy(
-        dst->memory,
-        src,
-        dst->alloc_size);
-    dst->len = len;
-    return (1);
+	if (!dst || !src || elem_size == 0)
+		return (-1);
+	else if (vec_new(dst, len, elem_size) < 0)
+		return (-1);
+	memcpy(
+		dst->memory,
+		src,
+		dst->alloc_size);
+	dst->len = len;
+	return (1);
 }
 
 int vec_copy(t_vec *dst, t_vec *src)
 {
-    size_t  copy_size;
+	size_t	copy_size;
 
-    if (!dst || !src || !src->memory)
-        return (-1);
-    else if (!dst->memory)
-        vec_new(dst, src->len, dst->elem_size);
-    if (src->len * src->elem_size < dst->alloc_size)
-        copy_size = src->len * src->elem_size;
-    else
-        copy_size = src->alloc_size;
-    memcpy(
-        dst->memory,
-        src->memory,
-        copy_size);
+	if (!dst || !src || !src->memory)
+		return (-1);
+	else if (!dst->memory)
+		vec_new(dst, src->len, dst->elem_size);
+	if (src->len * src->elem_size < dst->alloc_size)
+		copy_size = src->len * src->elem_size;
+	else
+		copy_size = src->alloc_size;
+	memcpy(
+		dst->memory,
+		src->memory,
+		copy_size);
 	dst->len = copy_size / dst->elem_size;
-    return (1);
+	return (1);
 }
 
 int vec_resize(t_vec *src, size_t target_len)
 {
-    t_vec   dst;
+	t_vec	dst;
 
-    if (!src)
-        return (-1);
-    else if (!src->memory)
-        return vec_new(src, target_len, src->elem_size);
-    else if (vec_new(&dst, target_len, src->elem_size) < 0)
-        return (-1);
-    memcpy(
-        dst.memory,
-        src->memory,
-        src->len * src->elem_size);
-    dst.len = src->len;
-    vec_free(src);
-    *src = dst;
-    return (1);
+	if (!src)
+		return (-1);
+	else if (!src->memory)
+		return vec_new(src, target_len, src->elem_size);
+	else if (vec_new(&dst, target_len, src->elem_size) < 0)
+		return (-1);
+	memcpy(
+		dst.memory,
+		src->memory,
+		src->len * src->elem_size);
+	dst.len = src->len;
+	vec_free(src);
+	*src = dst;
+	return (1);
 }
 
 void *vec_get(t_vec *src, size_t index)
 {
-    unsigned char   *ptr;
+	unsigned char	*ptr;
 
-    if (index >= src->len || !src || !src->memory)
-        return (NULL);
-    ptr = &src->memory[src->elem_size * index];
-    return (ptr);
+	if (index >= src->len || !src || !src->memory)
+		return (NULL);
+	ptr = &src->memory[src->elem_size * index];
+	return (ptr);
 }
 
 int vec_push(t_vec *dst, void *src)
 {
-    if (!dst || !src)
-        return (-1);
-    else if (!dst->memory)
-        vec_new(dst, 1, dst->elem_size);
-    if (dst->elem_size * dst->len >= dst->alloc_size)
-        if (vec_resize(dst, dst->len * 2) < 0)
-            return (-1);
-    memcpy(&dst->memory[dst->elem_size * dst->len], src, dst->elem_size);
-    dst->len++;
-    return (1);
+	if (!dst || !src)
+		return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
+	if (dst->elem_size * dst->len >= dst->alloc_size)
+		if (vec_resize(dst, dst->len * 2) < 0)
+			return (-1);
+	memcpy(&dst->memory[dst->elem_size * dst->len], src, dst->elem_size);
+	dst->len++;
+	return (1);
 }
 
 int vec_pop(void *dst, t_vec *src)
 {
-    if (!dst || !src)
-        return (-1);
-    else if (!src->memory || src->len == 0)
-        return (0);
-    memcpy(dst, vec_get(src, src->len - 1), src->elem_size);
-    src->len--;
-    return (1);
+	if (!dst || !src)
+		return (-1);
+	else if (!src->memory || src->len == 0)
+		return (0);
+	memcpy(dst, vec_get(src, src->len - 1), src->elem_size);
+	src->len--;
+	return (1);
 }
 
 int vec_clear(t_vec *src)
 {
-    if (!src)
-        return (-1);
-    src->len = 0;
-    return (1);
+	if (!src)
+		return (-1);
+	src->len = 0;
+	return (1);
 }
 
 int vec_insert(t_vec *dst, void *src, size_t index)
 {
-    if (!dst || !src || index > dst->len)
-        return (-1);
-    else if (index == dst->len)
-        return (vec_push(dst, src));
-    if (dst->elem_size * dst->len >= dst->alloc_size)
-        if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
-            return (-1);
-    memmove(
-        vec_get(dst, index + 1),
-        vec_get(dst, index),
-        (dst->len - index) * dst->elem_size);
-    memcpy(
-        vec_get(dst, index),
-        src, dst->elem_size);
-    dst->len++;
-    return (1);
+	if (!dst || !src || index > dst->len)
+		return (-1);
+	else if (index == dst->len)
+		return (vec_push(dst, src));
+	if (dst->elem_size * dst->len >= dst->alloc_size)
+		if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
+			return (-1);
+	memmove(
+		vec_get(dst, index + 1),
+		vec_get(dst, index),
+		(dst->len - index) * dst->elem_size);
+	memcpy(
+		vec_get(dst, index),
+		src, dst->elem_size);
+	dst->len++;
+	return (1);
 }
 
 int vec_remove(t_vec *src, size_t index)
 {
-    if (!src || index > src->len)
-        return (-1);
-    else if (index == src->len)
-    {
-        src->len--;
-        return (1);
-    }
-    memmove(
-        vec_get(src, index),
-        &src->memory[src->elem_size * (index + 1)],
-        (src->len - index) * src->elem_size);
-    src->len--;
-    return (1);
+	if (!src || index > src->len)
+		return (-1);
+	else if (index == src->len)
+	{
+		src->len--;
+		return (1);
+	}
+	memmove(
+		vec_get(src, index),
+		&src->memory[src->elem_size * (index + 1)],
+		(src->len - index) * src->elem_size);
+	src->len--;
+	return (1);
 }
 
 int vec_append(t_vec *dst, t_vec *src)
 {
-    int     ret;
-    size_t  alloc_size;
+	int		ret;
+	size_t	alloc_size;
 
-    if (!dst || !src || !src->memory)
-        return (-1);
-    else if (!dst->memory)
-        vec_new(dst, 1, dst->elem_size);
-    alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
-    if (dst->alloc_size < alloc_size)
-    {
-        if (dst->alloc_size * 2 < dst->len * alloc_size)
-            ret = vec_resize(dst, alloc_size);
-        else
-            ret = vec_resize(dst, dst->alloc_size * 2);
-        if (ret < 0)
-            return (-1);
-    }
-    memcpy(
-        &dst->memory[dst->elem_size * dst->len],
-        src->memory,
-        src->len * src->elem_size);
-    dst->len += src->len;
-    return (1);
+	if (!dst || !src || !src->memory)
+		return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
+	alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
+	if (dst->alloc_size < alloc_size)
+	{
+		if (dst->alloc_size * 2 < dst->len * alloc_size)
+			ret = vec_resize(dst, alloc_size);
+		else
+			ret = vec_resize(dst, dst->alloc_size * 2);
+		if (ret < 0)
+			return (-1);
+	}
+	memcpy(
+		&dst->memory[dst->elem_size * dst->len],
+		src->memory,
+		src->len * src->elem_size);
+	dst->len += src->len;
+	return (1);
 }
 
 int vec_prepend(t_vec *dst, t_vec *src)
 {
-    t_vec    new;
-    size_t   alloc_size;
+	t_vec	 new;
+	size_t	 alloc_size;
 
-    if (!dst || !src)
-        return (-1);
-    else if (!dst->memory)
-        vec_new(dst, 1, dst->elem_size);
-    alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
-    if (vec_new(&new, alloc_size / dst->elem_size, dst->elem_size) < 0)
-        return (-1);
-    vec_copy(&new, src);
-    new.len = src->len + dst->len;
-    memcpy(
-        &new.memory[dst->elem_size * dst->len],
-        dst->memory,
-        dst->len * dst->elem_size);
-    vec_free(dst);
-    *dst = new;
-    return (1);
+	if (!dst || !src)
+		return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
+	alloc_size = dst->len * dst->elem_size + src->len * src->elem_size;
+	if (vec_new(&new, alloc_size / dst->elem_size, dst->elem_size) < 0)
+		return (-1);
+	vec_copy(&new, src);
+	new.len = src->len + dst->len;
+	memcpy(
+		&new.memory[dst->elem_size * dst->len],
+		dst->memory,
+		dst->len * dst->elem_size);
+	vec_free(dst);
+	*dst = new;
+	return (1);
 }
 
 void vec_iter(t_vec *src, void (*f) (void *))
 {
-    void    *ptr;
-    size_t  i;
+	void	*ptr;
+	size_t	i;
 
-    if (!src || !src->memory)
-        return ;
-    i = 0;
-    while (i < src->len)
-    {
-        ptr = vec_get(src, i);
-        f(ptr);
-        i++;
-    }
+	if (!src || !src->memory)
+		return ;
+	i = 0;
+	while (i < src->len)
+	{
+		ptr = vec_get(src, i);
+		f(ptr);
+		i++;
+	}
 }
 
 void *vec_find(t_vec *src, bool (*f) (void *))
 {
-    void    *ptr;
-    size_t  i;
+	void	*ptr;
+	size_t	i;
 
-    if (!src || !src->memory)
-        return (NULL);
-    i = 0;
-    while (i < src->len)
-    {
-        ptr = vec_get(src, i);
-        if (f(ptr) == true)
-            return (ptr);
-        i++;
-    }
-    return (NULL);
+	if (!src || !src->memory)
+		return (NULL);
+	i = 0;
+	while (i < src->len)
+	{
+		ptr = vec_get(src, i);
+		if (f(ptr) == true)
+			return (ptr);
+		i++;
+	}
+	return (NULL);
 }
 
 int vec_map(t_vec *dst, t_vec *src, void (*f) (void *))
 {
-    void    *ptr;
-    void    *res;
-    size_t  i;
+	void	*ptr;
+	void	*res;
+	size_t	i;
 
-    if (!dst || !src || !src->memory)
-        return (-1);
-    else if (!dst->memory)
-        vec_new(dst, 1, dst->elem_size);
-    res = malloc(dst->elem_size);
-    if (!res)
-        return (-1);
-    i = 0;
-    while (i < src->len)
-    {
-        ptr = vec_get(src, i);
-        memcpy(res, ptr, dst->elem_size);
-        f(res);
-        vec_push(dst, res);
-        i++;
-    }
-    free(res);
-    return (1);
+	if (!dst || !src || !src->memory)
+		return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
+	res = malloc(dst->elem_size);
+	if (!res)
+		return (-1);
+	i = 0;
+	while (i < src->len)
+	{
+		ptr = vec_get(src, i);
+		memcpy(res, ptr, dst->elem_size);
+		f(res);
+		vec_push(dst, res);
+		i++;
+	}
+	free(res);
+	return (1);
 }
 
 int vec_filter(t_vec *dst, t_vec *src, bool (*f) (void *))
 {
-    void    *ptr;
-    void    *res;
-    size_t  i;
+	void	*ptr;
+	void	*res;
+	size_t	i;
 
-    if (!dst || !src || !src->memory)
-        return (-1);
-    else if (!dst->memory)
-        vec_new(dst, 1, dst->elem_size);
-    res = malloc(dst->elem_size);
-    if (!res)
-        return (-1);
-    i = 0;
-    while (i < src->len)
-    {
-        ptr = vec_get(src, i);
-        memcpy(res, ptr, dst->elem_size);
-        if (f(res) == true)
-            vec_push(dst, res);
-        i++;
-    }
-    free(res);
-    return (1);
+	if (!dst || !src || !src->memory)
+		return (-1);
+	else if (!dst->memory)
+		vec_new(dst, 1, dst->elem_size);
+	res = malloc(dst->elem_size);
+	if (!res)
+		return (-1);
+	i = 0;
+	while (i < src->len)
+	{
+		ptr = vec_get(src, i);
+		memcpy(res, ptr, dst->elem_size);
+		if (f(res) == true)
+			vec_push(dst, res);
+		i++;
+	}
+	free(res);
+	return (1);
 }
 
 int vec_reduce(void *dst, t_vec *src, void (*f) (void *, void *))
 {
-    void    *ptr;
-    size_t  i;
+	void	*ptr;
+	size_t	i;
 
-    if (!dst || !src || !src->memory)
-        return (-1);
-    i = 0;
-    while (i < src->len)
-    {
-        ptr = vec_get(src, i);
-        f(dst, ptr);
-        i++;
-    }
-    return (1);
+	if (!dst || !src || !src->memory)
+		return (-1);
+	i = 0;
+	while (i < src->len)
+	{
+		ptr = vec_get(src, i);
+		f(dst, ptr);
+		i++;
+	}
+	return (1);
 }
 
 static void memswap8(unsigned char *a, unsigned char *b)
 {
-    if (a == b)
-        return ;
-    *a ^= *b;
-    *b ^= *a;
-    *a ^= *b;
+	if (a == b)
+		return ;
+	*a ^= *b;
+	*b ^= *a;
+	*a ^= *b;
 }
 
 static void memswap(unsigned char *a, unsigned char *b, size_t bytes)
 {
-    size_t  i;
+	size_t	i;
 
-    if (!a || !b)
-        return ;
-    i = 0;
-    while (i < bytes)
-    {
-        memswap8(&a[i], &b[i]);
-        i++;
-    }
+	if (!a || !b)
+		return ;
+	i = 0;
+	while (i < bytes)
+	{
+		memswap8(&a[i], &b[i]);
+		i++;
+	}
 }
 
 static void vec_sort_recurse(t_vec *src,
-    long int low,
-    long int high,
-    int (*f)(void *, void *))
+	long int low,
+	long int high,
+	int (*f)(void *, void *))
 {
-    long int pivot;
-    long int a;
-    long int b;
+	long int pivot;
+	long int a;
+	long int b;
 
-    if (low >= high)
-        return ;
-    pivot = low;
-    a = low;
-    b = high;
-    while (a < b)
-    {
-        while (a <= high && f(vec_get(src, a), vec_get(src, pivot)) <= 0)
-            a++;
-        while (b >= low && f(vec_get(src, b), vec_get(src, pivot)) > 0)
-            b--;
-        if (a < b)
-            memswap(vec_get(src, a), vec_get(src, b), src->elem_size);
-    }
-    memswap(vec_get(src, pivot), vec_get(src, b), src->elem_size);
-    vec_sort_recurse(src, low, b - 1, f);
-    vec_sort_recurse(src, b + 1, high, f);
+	if (low >= high)
+		return ;
+	pivot = low;
+	a = low;
+	b = high;
+	while (a < b)
+	{
+		while (a <= high && f(vec_get(src, a), vec_get(src, pivot)) <= 0)
+			a++;
+		while (b >= low && f(vec_get(src, b), vec_get(src, pivot)) > 0)
+			b--;
+		if (a < b)
+			memswap(vec_get(src, a), vec_get(src, b), src->elem_size);
+	}
+	memswap(vec_get(src, pivot), vec_get(src, b), src->elem_size);
+	vec_sort_recurse(src, low, b - 1, f);
+	vec_sort_recurse(src, b + 1, high, f);
 }
 
-void    vec_sort(t_vec *src, int (*f)(void *, void *))
+void	vec_sort(t_vec *src, int (*f)(void *, void *))
 {
-    if (!src || !src->memory)
-        return ;
-    vec_sort_recurse(src, 0, src->len - 1, f);
+	if (!src || !src->memory)
+		return ;
+	vec_sort_recurse(src, 0, src->len - 1, f);
 }

--- a/vec.c
+++ b/vec.c
@@ -59,7 +59,7 @@ int vec_copy(t_vec *dst, t_vec *src)
         dst->memory,
         src->memory,
         copy_size);
-        dst->len = copy_size / dst->elem_size;
+	dst->len = copy_size / dst->elem_size;
     return (1);
 }
 
@@ -78,7 +78,6 @@ int vec_resize(t_vec *src, size_t target_len)
         src->memory,
         src->len * src->elem_size);
     dst.len = src->len;
-    vec_copy(&dst, src);
     vec_free(src);
     *src = dst;
     return (1);
@@ -101,7 +100,7 @@ int vec_push(t_vec *dst, void *src)
     else if (!dst->memory)
         vec_new(dst, 1, dst->elem_size);
     if (dst->elem_size * dst->len >= dst->alloc_size)
-        if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
+        if (vec_resize(dst, dst->len * 2) < 0)
             return (-1);
     memcpy(&dst->memory[dst->elem_size * dst->len], src, dst->elem_size);
     dst->len++;

--- a/vec.c
+++ b/vec.c
@@ -88,7 +88,7 @@ void *vec_get(t_vec *src, size_t index)
 {
     unsigned char   *ptr;
 
-    if (index > src->len || !src || !src->memory)
+    if (index >= src->len || !src || !src->memory)
         return (NULL);
     ptr = &src->memory[src->elem_size * index];
     return (ptr);
@@ -103,7 +103,7 @@ int vec_push(t_vec *dst, void *src)
     if (dst->elem_size * dst->len >= dst->alloc_size)
         if (vec_resize(dst, (dst->alloc_size * 2) / dst->elem_size) < 0)
             return (-1);
-    memcpy(vec_get(dst, dst->len), src, dst->elem_size);
+    memcpy(&dst->memory[dst->elem_size * dst->len], src, dst->elem_size);
     dst->len++;
     return (1);
 }
@@ -158,7 +158,7 @@ int vec_remove(t_vec *src, size_t index)
     }
     memmove(
                 vec_get(src, index),
-                vec_get(src, index + 1),
+                &src->memory[src->elem_size * (index + 1)],
                 (src->len - index) * src->elem_size);
     src->len--;
     return (1);
@@ -184,9 +184,9 @@ int vec_append(t_vec *dst, t_vec *src)
             return (-1);
     }
     memcpy(
-                vec_get(dst, dst->len),
-                src->memory,
-                src->len * src->elem_size);
+        &dst->memory[dst->elem_size * dst->len],
+        src->memory,
+        src->len * src->elem_size);
     dst->len += src->len;
     return (1);
 }
@@ -206,9 +206,9 @@ int vec_prepend(t_vec *dst, t_vec *src)
     vec_copy(&new, src);
     new.len = src->len + dst->len;
     memcpy(
-                vec_get(&new, src->len),
-                dst->memory,
-                dst->len * dst->elem_size);
+        &new.memory[dst->elem_size * dst->len],
+        dst->memory,
+        dst->len * dst->elem_size);
     vec_free(dst);
     *dst = new;
     return (1);

--- a/vec.h
+++ b/vec.h
@@ -14,10 +14,11 @@ typedef struct s_vec
 	size_t			len;
 }	t_vec;
 
-int		vec_new(t_vec *src, size_t init_alloc, size_t elem_size);
+int		vec_new(t_vec *src, size_t init_len, size_t elem_size);
 void	vec_free(t_vec *src);
 int		vec_from(t_vec *dst, void *src, size_t len, size_t elem_size);
 int		vec_resize(t_vec *src, size_t target_size);
+int		vec_clear(t_vec *src);
 int	 	vec_push(t_vec *src, void *elem);
 int	 	vec_pop(void *dst, t_vec *src);
 int	 	vec_copy(t_vec *dst, t_vec *src);
@@ -27,6 +28,7 @@ int		vec_remove(t_vec *src, size_t index);
 int	 	vec_append(t_vec *dst, t_vec *src);
 int	 	vec_prepend(t_vec *dst, t_vec *src);
 void	vec_iter(t_vec *src, void (*f) (void *));
+void	*vec_find(t_vec *src, bool (*f) (void *));
 int		vec_map(t_vec *dst, t_vec *src, void (*f) (void *));
 int		vec_filter(t_vec *dst, t_vec *src, bool (*f) (void *));
 int	 	vec_reduce(void *dst, t_vec *src, void (*f) (void *, void *));


### PR DESCRIPTION
- Implemented lazy initialization for the vector. Now if user passes init_len == 0 to `vec_new`, memory won't be allocated at this point, but when the vector is first used (push, insert, etc).
- Implemented `vec_clear` that just changes the length of the vector to zero reserving all allocated space.
- Implemented `vec_find` a simple search taking `f` comaprison method as arg.