### PR TITLE
subject.md fixed missing vec_free causing a leak

### DIFF
--- a/subject.md
+++ b/subject.md
@@ -567,6 +567,7 @@ int main(void)
     assert(vec_from(&t1, base, 5, sizeof(int)) > 0);
     vec_sort(&t1, cmp);
     assert(memcmp(t1.memory, expect, sizeof(expect)) == 0);
+    vec_free(&t1);
     printf("test_vec_sort successful!\n");
 }
 


### PR DESCRIPTION
## What?
Added a missing call to `vec_free` within the suggested test main for `vec_sort` in `subject.md`.
## Why?
The change introduces an exemplary-level main to test `vec_sort` with.
## Testing?
Not yet tested with the example implementation. Tested with my own implementation of [teemu-hakala/c-vec](https://github.com/teemu-hakala/c-vec/tree/teemu-hakala).